### PR TITLE
Add function to return list of wav files

### DIFF
--- a/src/hcr.cpp
+++ b/src/hcr.cpp
@@ -32,31 +32,31 @@
 }; */
 
 HCRVocalizer::HCRVocalizer(const uint8_t addr, TwoWire &i2c)
-    : _i2caddr(addr), _i2c(&i2c), _serialBaud(400000)
+    : _i2caddr(addr), _i2c(&i2c), _serialBaud(400000), _wavFileList(nullptr), _wavFileListSize(0)
 {
     connectionType=0x03;
 }
 
 HCRVocalizer::HCRVocalizer(const uint8_t addr, TwoWire &i2c, int baud)
-    : _i2caddr(addr), _i2c(&i2c), _serialBaud(baud)
+    : _i2caddr(addr), _i2c(&i2c), _serialBaud(baud), _wavFileList(nullptr), _wavFileListSize(0)
 {
     connectionType=0x03;
 }
 
 HCRVocalizer::HCRVocalizer(HardwareSerial *conn,int baud)
-    : _serial(conn), _serialBaud(baud)
+    : _serial(conn), _serialBaud(baud), _wavFileList(nullptr), _wavFileListSize(0)
 {
     connectionType=0x01;
 }
 
 HCRVocalizer::HCRVocalizer(SoftwareSerial *conn,int baud)
-    : _softserial(conn), _serialBaud(baud)
+    : _softserial(conn), _serialBaud(baud), _wavFileList(nullptr), _wavFileListSize(0)
 {
     connectionType=0x02;
 }
 
 HCRVocalizer::HCRVocalizer(int rx, int tx,int baud)
-    : _serialBaud(9600)
+    : _serialBaud(9600), _wavFileList(nullptr), _wavFileListSize(0)
 {
     #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_PIC32)
     connectionType=0x02;
@@ -586,4 +586,40 @@ String HCRVocalizer::getValue(String data, char separator, int index)
   }
 
   return found>index ? data.substring(strIndex[0], strIndex[1]) : "";
+}
+
+String HCRVocalizer::GetWAVFileName(int fileIndex)
+{
+    if (fileIndex < 0 || fileIndex >= GetWAVCount()) {
+        return "";
+    }
+    
+    String fileName = String(fileIndex, DEC);
+    while (fileName.length() < 4) {
+        fileName = "0" + fileName;
+    }
+    fileName += ".WAV";
+    
+    return fileName;
+}
+
+String* HCRVocalizer::GetWAVFileList(void)
+{
+    int count = GetWAVCount();
+    
+    // Free existing list if any
+    if (_wavFileList != nullptr) {
+        delete[] _wavFileList;
+    }
+    
+    // Create new array
+    _wavFileList = new String[count];
+    _wavFileListSize = count;
+    
+    // Populate with filenames
+    for (int i = 0; i < count; i++) {
+        _wavFileList[i] = GetWAVFileName(i);
+    }
+    
+    return _wavFileList;
 }

--- a/src/hcr.h
+++ b/src/hcr.h
@@ -307,6 +307,23 @@ public:
     float getVolume(int e);
     void getUpdate(void);
 
+    /**
+     * @brief Returns the filename of the WAV file at the specified index
+     * Files are named sequentially (0000.WAV, 0001.WAV, etc.) by default
+     * 
+     * @param fileIndex the index of the file (0 to GetWAVCount()-1)
+     * @return String the filename (e.g., "0000.WAV")
+     */
+    String GetWAVFileName(int fileIndex);
+
+    /**
+     * @brief Returns an array of all WAV filenames currently on the SD card
+     * Caller is responsible for managing the returned array memory
+     * 
+     * @return String* pointer to an array of filenames
+     */
+    String* GetWAVFileList(void);
+
     void dfPlayer();
 
 private:
@@ -347,6 +364,8 @@ protected:
     int Volume_V;
     int Volume_A;
     int Volume_B;
+    String* _wavFileList;
+    int _wavFileListSize;
 };
 
 using namespace std;


### PR DESCRIPTION
This returns a list of the wav files by number. It does not account for the fact that file numbers may be non-sequential, but it at least does return a list for potential use later, like possibly scrolling through the list and picking one to play.